### PR TITLE
Use .test since it's a reserved TLD

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ In ./example.com/:
 2. Rename `env.example` to `.env`.
 3. `docker-compose up -d`
 
-Lastly, add example.local to your `/etc/hosts`.
+Lastly, add example.test to your `/etc/hosts`.
 
-WordPress installation screen should be available at `example.local`.
+WordPress installation screen should be available at `example.test`.
 
 You can monitor the traefik web GUI at `localhost`.
 
@@ -35,7 +35,7 @@ These are the files you'll want to add (root is bedrock):
 
 ``` env
 # Docker local
-DEV_WP=example.local
+DEV_WP=example.test
 DEV_WP_HOME=http://${DEV_WP}
 DEV_WP_SITEURL=${DEV_WP_HOME}/wp
 ```

--- a/example.com/config/docker/site.nginx.conf
+++ b/example.com/config/docker/site.nginx.conf
@@ -1,6 +1,6 @@
 server {
   index index.php index.html;
-  server_name example.local;
+  server_name example.test;
   error_log  /var/log/nginx/error.log;
   access_log /var/log/nginx/access.log;
   root /code/web;

--- a/example.com/env.example
+++ b/example.com/env.example
@@ -22,6 +22,6 @@ LOGGED_IN_SALT='generateme'
 NONCE_SALT='generateme'
 
 # Docker local
-DEV_WP=example.local
-DEV_WP_HOME=http://${DEV_WP} 
+DEV_WP=example.test
+DEV_WP_HOME=http://${DEV_WP}
 DEV_WP_SITEURL=${DEV_WP_HOME}/wp


### PR DESCRIPTION
First of all, this is awesome. I tried out just the repo and it works. 🎉 I'll let you know how usage on an existing project goes. I did make a bit of a modification that I'll explain below:

Unfortunately, sometimes there can be conflicts with `.local` since it is used by other services (e.g. Bonjour on macOS). Fortunately, there is a shortlist of reserved TLDs for testing:

* `.test`
* `.localhost`
* `.example`
* `.invalid`

You don’t have to change it, I thought it might be a good idea though — helps avoid any "Google owns `.dev` so you can’t use it anymore" situations. Also, if you'd like I can change it one of the other options on the list, I just use `.test` because it's pretty common.

Reference: https://tools.ietf.org/html/rfc2606